### PR TITLE
Default properties fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,5 @@ bin
 src/log4j.properties
 alfresco.log
 *.jar
+.idea/*
+*.iml

--- a/src/main/amp/config/alfresco/module/alfresco-trashcan-cleaner/alfresco-global.properties
+++ b/src/main/amp/config/alfresco/module/alfresco-trashcan-cleaner/alfresco-global.properties
@@ -1,0 +1,3 @@
+trashcan.cron=0 30 * * * ?
+trashcan.daysToKeep=1
+trashcan.deleteBatchCount=1000

--- a/src/main/amp/config/alfresco/module/alfresco-trashcan-cleaner/log4j.properties
+++ b/src/main/amp/config/alfresco/module/alfresco-trashcan-cleaner/log4j.properties
@@ -37,4 +37,5 @@
 #       those in the webapp's main log4j.properties.
 #    
 #-----------------------------------------------------------------------
-log4j.logger.org.alfresco.demoamp.DemoComponent=${module.log.level}
+#log4j.logger.org.alfresco.demoamp.DemoComponent=${module.log.level}
+log4j.logger.org.alfresco.trashcan=info


### PR DESCRIPTION
This fix eliminates error when properties trashcan.cron, trashcan.daysToKeep and trashcan.deleteBatchCount is not set in general alfresco-global.properties file.